### PR TITLE
feat: batch likes in syncing for uncensorable contracts

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -17,13 +17,14 @@ export const SECOND_TITLE = 'Google';
 export const SECOND_URL = 'https://google.com/';
 export const SECOND_TAG = 'web-search';
 
-export const USERS_TO_ADD = [
-  {
-    userAddress: '0xE4721A80C6e56f4ebeed6acEE91b3ee715e7dD64',
-    numberOfLikedContent: 0,
-    submittedContent: [1],
-  },
-];
+// export const USERS_TO_ADD = [
+//   {
+//     userAddress: '0xE4721A80C6e56f4ebeed6acEE91b3ee715e7dD64',
+//     numberOfLikedContent: 0,
+//     submittedContent: [1],
+//   },
+// ];
+export const USERS_TO_ADD = ["0xE4721A80C6e56f4ebeed6acEE91b3ee715e7dD64"];
 export const TAGS_TO_ADD = [
   {
     name: 'music',

--- a/constants.ts
+++ b/constants.ts
@@ -4,6 +4,8 @@ export const BACKEND_PUBLIC_ADDRESS =
   '0xb4a5714dd934a3391Bc670BEc9aee18b821e1Fd5';
 export const BACKEND_PRIVATE_KEY =
   'bd0cef31fef0e40085b0f2801744057feb0a6b3d3a7d96d01eac0c08eea2e596';
+export const USER_PUBLIC_ADDRESS = 
+  '0xE4721A80C6e56f4ebeed6acEE91b3ee715e7dD64';
 
 export const BACKEND_REGISTRATION_FEE = ethers.parseEther('0.01');
 export const SLASHING_FEE = ethers.parseEther('0.001');
@@ -24,11 +26,11 @@ export const SECOND_TAG = 'web-search';
 //     submittedContent: [1],
 //   },
 // ];
-export const USERS_TO_ADD = ["0xE4721A80C6e56f4ebeed6acEE91b3ee715e7dD64"];
+export const USERS_TO_ADD = [USER_PUBLIC_ADDRESS];
 export const TAGS_TO_ADD = [
   {
     name: 'music',
-    createdBy: '0xE4721A80C6e56f4ebeed6acEE91b3ee715e7dD64',
+    createdBy: USER_PUBLIC_ADDRESS,
     contentIds: ['https://google.com/', 'https://inno-maps.com/'],
   },
 ];
@@ -36,7 +38,7 @@ export const CONTENT_TO_ADD = [
   {
     title: 'Innomaps',
     url: 'https://inno-maps.com/',
-    submittedBy: '0xE4721A80C6e56f4ebeed6acEE91b3ee715e7dD64',
+    submittedBy: USER_PUBLIC_ADDRESS,
     likes: 0,
     tagIds: ['zero-knowledge', 'web-search'],
   },

--- a/contracts/Channel4Contract.sol
+++ b/contracts/Channel4Contract.sol
@@ -20,4 +20,30 @@ contract Channel4Contract is Data, Create, Interact, Litigate {
     Interact()
     Litigate(slashingFee, backendRegistrationFee)
     {}
+
+    /// @notice Sync Content state with the backend. Only Content, Tag and User elements that have been updated
+    /// @dev It can be called only by the backend to sync the state of the URLs
+    function syncState(
+        address[] calldata usersToAdd,
+        TagToAdd[] calldata tagsToAdd,
+        ContentToAdd[] calldata contentsToAdd
+    ) public onlyBackend {
+        for (uint256 i = 0; i < usersToAdd.length; i++)
+            _createUserIfNotExists(usersToAdd[i]);
+        for (uint256 i = 0; i < tagsToAdd.length; i++) {
+            _createTagIfNotExists(
+                tagsToAdd[i].name,
+                tagsToAdd[i].createdBy
+            );
+        }
+        for (uint256 i = 0; i < contentsToAdd.length; i++) {
+            _createContentIfNotExists(
+                contentsToAdd[i].title,
+                contentsToAdd[i].url,
+                contentsToAdd[i].submittedBy,
+                contentsToAdd[i].likes,
+                contentsToAdd[i].tagIds
+            );
+        }
+    }
 }

--- a/contracts/Channel4Contract.sol
+++ b/contracts/Channel4Contract.sol
@@ -29,8 +29,8 @@ contract Channel4Contract is Data, Create, Interact, Litigate {
     /// @param pendingActions - pending like/unlike actions to facilitate
     function syncState(
         address[] calldata usersToAdd,
-        TagToAdd[] calldata tagsToAdd,
-        ContentToAdd[] calldata contentsToAdd,
+        TagToSync[] calldata tagsToAdd,
+        ContentToSync[] calldata contentsToAdd,
         Pending[] calldata pendingActions
     ) public onlyBackend {
         for (uint256 i = 0; i < usersToAdd.length; i++)
@@ -46,7 +46,7 @@ contract Channel4Contract is Data, Create, Interact, Litigate {
                 contentsToAdd[i].title,
                 contentsToAdd[i].url,
                 contentsToAdd[i].submittedBy,
-                contentsToAdd[i].likes,
+                0,
                 contentsToAdd[i].tagIds
             );
         }

--- a/contracts/Channel4Contract.sol
+++ b/contracts/Channel4Contract.sol
@@ -23,10 +23,15 @@ contract Channel4Contract is Data, Create, Interact, Litigate {
 
     /// @notice Sync Content state with the backend. Only Content, Tag and User elements that have been updated
     /// @dev It can be called only by the backend to sync the state of the URLs
+    /// @param usersToAdd - addresses of new users to enroll in the contract
+    /// @param tagsToAdd - tags to add to the contract
+    /// @param contentsToAdd - url contents to add to the contract
+    /// @param pendingActions - pending like/unlike actions to facilitate
     function syncState(
         address[] calldata usersToAdd,
         TagToAdd[] calldata tagsToAdd,
-        ContentToAdd[] calldata contentsToAdd
+        ContentToAdd[] calldata contentsToAdd,
+        Pending[] calldata pendingActions
     ) public onlyBackend {
         for (uint256 i = 0; i < usersToAdd.length; i++)
             _createUserIfNotExists(usersToAdd[i]);
@@ -44,6 +49,9 @@ contract Channel4Contract is Data, Create, Interact, Litigate {
                 contentsToAdd[i].likes,
                 contentsToAdd[i].tagIds
             );
+        }
+        for (uint i = 0; i < pendingActions.length; i++) {
+            toggleLike(pendingActions[i].url, pendingActions[i].submittedBy);
         }
     }
 }

--- a/contracts/Create.sol
+++ b/contracts/Create.sol
@@ -130,35 +130,4 @@ abstract contract Create is Data, OnlyBackend {
     ) public onlyBackend returns (uint256) {
         return _createUserIfNotExists(userAddress);
     }
-
-    /// @notice Sync Content state with the backend. Only Content, Tag and User elements that have been updated
-    /// @dev It can be called only by the backend to sync the state of the URLs
-    function syncState(
-        User[] calldata usersToAdd,
-        TagToAdd[] calldata tagsToAdd,
-        ContentToAdd[] calldata contentsToAdd
-    ) public onlyBackend {
-        for (uint256 i = 0; i < usersToAdd.length; i++) {
-            uint256 userIndex = _createUserIfNotExists(
-                usersToAdd[i].userAddress
-            );
-            users.list[userIndex].numberOfLikedContent = usersToAdd[i].numberOfLikedContent;
-            users.list[userIndex].submittedContent = usersToAdd[i].submittedContent;
-        }
-        for (uint256 i = 0; i < tagsToAdd.length; i++) {
-            _createTagIfNotExists(
-                tagsToAdd[i].name,
-                tagsToAdd[i].createdBy
-            );
-        }
-        for (uint256 i = 0; i < contentsToAdd.length; i++) {
-            _createContentIfNotExists(
-                contentsToAdd[i].title,
-                contentsToAdd[i].url,
-                contentsToAdd[i].submittedBy,
-                contentsToAdd[i].likes,
-                contentsToAdd[i].tagIds
-            );
-        }
-    }
 }

--- a/contracts/Data.sol
+++ b/contracts/Data.sol
@@ -53,6 +53,11 @@ abstract contract Data {
         mapping (address => mapping (uint256 => bool)) likedContent;
     }
 
+    struct Pending {
+        address submittedBy;
+        string url;
+    }
+
     Contents contents;
     Tags tags;
     Users users;

--- a/contracts/Data.sol
+++ b/contracts/Data.sol
@@ -31,10 +31,22 @@ abstract contract Data {
         string[] tagIds;
     }
 
+    struct ContentToSync {
+        string title;
+        string url;
+        address submittedBy;
+        string[] tagIds;
+    }
+
     struct TagToAdd {
         string name;
         address createdBy;
         string[] contentIds;
+    }
+
+    struct TagToSync {
+        string name;
+        address createdBy;
     }
 
     struct Contents {

--- a/contracts/Interact.sol
+++ b/contracts/Interact.sol
@@ -7,33 +7,31 @@ import { OnlyBackend } from "./OnlyBackend.sol";
 abstract contract Interact is Data, OnlyBackend {
     /// Interaction functions
 
-    /// @notice Like a specific content
-    /// @param url content url (works as an id)
-    /// @param submittedBy user that submitted the content
-    function likeContent(string memory url, address submittedBy) public onlyBackend {
-        uint256 indexContent = contents.ids[url];
-        address userAddress = submittedBy;
-        uint256 userIndex = users.ids[userAddress];
-        User storage user = users.list[userIndex];
-
-        require(users.likedContent[userAddress][indexContent] == false, "Content already liked");
-        user.numberOfLikedContent = user.numberOfLikedContent + 1;
-        users.likedContent[userAddress][indexContent] = true;
-        contents.list[indexContent].likes = contents.list[indexContent].likes + 1;
-    }
-
-    /// @notice Unlike a specific URL
-    /// @param url content url (works as an id)
-    /// @param submittedBy user that submitted the content
-    function unlikeContent(string memory url, address submittedBy) public onlyBackend {
-        uint256 indexContent = contents.ids[url];
-        address userAddress = submittedBy;
-        uint256 userIndex = users.ids[userAddress];
-        User storage user = users.list[userIndex];
-
-        require(users.likedContent[userAddress][indexContent] == true, "Content already unliked");
-        user.numberOfLikedContent = user.numberOfLikedContent - 1;
-        users.likedContent[userAddress][indexContent] = false;
-        contents.list[indexContent].likes = contents.list[indexContent].likes - 1;
+    /// @notice toggles like status by a given user for given content
+    /// @dev this function can only be called by the backend
+    /// @dev todo: change string to id to save gas
+    /// @param url - the content to like or unlike
+    /// @param submittedBy - the user that is liking or unliking content
+    function toggleLike(
+        string memory url,
+        address submittedBy
+    ) public onlyBackend {
+        // index of content in id map
+        uint256 contentId = contents.ids[url];
+        // mutable reference to user storage
+        User storage user = users.list[users.ids[submittedBy]];
+        // check if user already liked the content
+        bool alreadyLiked = users.likedContent[submittedBy][contentId];
+        
+        // toggle binary like state of content for user
+        users.likedContent[submittedBy][contentId] = !alreadyLiked;
+        // increment or decrement user's liked content sum
+        user.numberOfLikedContent = alreadyLiked
+            ? user.numberOfLikedContent - 1
+            : user.numberOfLikedContent + 1;
+        // increment or decrement content's like sum
+        contents.list[contentId].likes = alreadyLiked
+            ? contents.list[contentId].likes - 1
+            : contents.list[contentId].likes + 1;
     }
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -19,6 +19,12 @@ const config: HardhatUserConfig = {
         'bd0cef31fef0e40085b0f2801744057feb0a6b3d3a7d96d01eac0c08eea2e596',
       ],
     },
+    localhost: {
+      url: `http://localhost:8545`,
+      accounts: [
+        '2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6',
+      ]
+    }
   },
 };
 

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -1,15 +1,38 @@
 import { ethers } from 'hardhat';
-import { FIRST_TAG } from '../constants';
-
+import {
+  BACKEND_PRIVATE_KEY,
+  BACKEND_REGISTRATION_FEE,
+  FIRST_TAG,
+  FIRST_TITLE,
+  FIRST_URL,
+  SLASHING_FEE,
+} from '../constants';
 async function main() {
-  const UrlContract = await ethers.getContractFactory('UrlContract');
-  const urlContract = await UrlContract.deploy(FIRST_TAG);
-
-  await urlContract.deployed();
-
-  console.log(
-    `UrlContract deployed to ${urlContract.address} with first tag ${FIRST_TAG}`,
+  const network = await ethers.provider.getNetwork();
+  console.log(`Deploying Channel4Contract to ${network.name} (${network.chainId})...`)
+  
+  // deploy contract
+  const Channel4Contract = await ethers.getContractFactory('Channel4Contract');
+  const channel4Contract = await Channel4Contract.deploy(
+    FIRST_TITLE,
+    FIRST_URL,
+    FIRST_TAG,
+    SLASHING_FEE,
+    BACKEND_REGISTRATION_FEE,
   );
+  await channel4Contract.waitForDeployment();
+
+  // log deployment info
+  console.log(`====================================`);
+  console.log(`Channel4Contract deployed to '${await channel4Contract.getAddress()}'`);
+  console.log(`Deployment parameters: `);
+  console.log(` - First URL Title: "${FIRST_TITLE}"`);
+  console.log(` - First URL: "${FIRST_URL}"`);
+  console.log(` - First Tag: "${FIRST_TAG}"`);
+  console.log(` - Slashing Fee: ${ethers.formatEther(SLASHING_FEE)} ether`);
+  console.log(` - Backend Registration Fee: ${ethers.formatEther(BACKEND_REGISTRATION_FEE)} ether`);
+  console.log(`====================================`);
+  // @todo: etherscan verification
 }
 
 // We recommend this pattern to be able to use async/await everywhere

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -9,6 +9,7 @@ import {
 } from '../constants';
 async function main() {
   const network = await ethers.provider.getNetwork();
+  console.log(`====================================`);
   console.log(`Deploying Channel4Contract to ${network.name} (${network.chainId})...`)
   
   // deploy contract
@@ -32,6 +33,17 @@ async function main() {
   console.log(` - Slashing Fee: ${ethers.formatEther(SLASHING_FEE)} ether`);
   console.log(` - Backend Registration Fee: ${ethers.formatEther(BACKEND_REGISTRATION_FEE)} ether`);
   console.log(`====================================`);
+
+  // register deployer as backend
+  const [deployer] = await ethers.getSigners();
+  let tx = await channel4Contract.connect(deployer).registerBackend({
+    value: BACKEND_REGISTRATION_FEE,
+  });
+  await tx.wait();
+  console.log(`Registerd contract deployer ${deployer.address} as backend`);
+  console.log(`====================================`);
+
+
   // @todo: etherscan verification
 }
 

--- a/test/deploy.ts
+++ b/test/deploy.ts
@@ -71,7 +71,7 @@ describe('Deploy', function () {
     await expect(
       channel4Contract
         .connect(otherAccount1)
-        .syncState(USERS_TO_ADD, TAGS_TO_ADD, CONTENT_TO_ADD),
+        .syncState(USERS_TO_ADD, TAGS_TO_ADD, CONTENT_TO_ADD, []),
     ).to.be.revertedWith('Caller is not the backend');
   });
 

--- a/test/deploy.ts
+++ b/test/deploy.ts
@@ -91,13 +91,13 @@ describe('Deploy', function () {
     await expect(
       channel4Contract
         .connect(otherAccount1)
-        .likeContent(FIRST_URL, otherAccount1.address),
+        .toggleLike(FIRST_URL, otherAccount1.address),
     ).to.be.revertedWith('Caller is not the backend');
 
     await expect(
       channel4Contract
         .connect(otherAccount1)
-        .unlikeContent(FIRST_URL, otherAccount1.address),
+        .toggleLike(FIRST_URL, otherAccount1.address),
     ).to.be.revertedWith('Caller is not the backend');
   });
 });

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -91,7 +91,7 @@ export async function likeContentFixture() {
   } = await loadFixture(createContentIfNotExistsFixture);
   await channel4Contract
     .connect(backendWallet)
-    .likeContent(contentObj.url, otherAccount1.address);
+    .toggleLike(contentObj.url, otherAccount1.address);
   return {
     channel4Contract,
     deployer,

--- a/test/like.ts
+++ b/test/like.ts
@@ -23,7 +23,7 @@ describe('Like', async function () {
 
     await channel4Contract
       .connect(backendWallet)
-      .unlikeContent(contentObj.url, otherAccount1.address);
+      .toggleLike(contentObj.url, otherAccount1.address);
     const content = await channel4Contract.getContent(contentObj.url);
     expect(Number(content.likes)).to.equal(0);
 

--- a/test/sync.ts
+++ b/test/sync.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { ethers } from 'hardhat';
 import { deployContractFixture } from './fixtures';
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import {
@@ -8,6 +9,7 @@ import {
   FIRST_URL,
   TAGS_TO_ADD,
   USERS_TO_ADD,
+  USER_PUBLIC_ADDRESS
 } from '../constants';
 
 describe('Sync', async function () {
@@ -17,7 +19,7 @@ describe('Sync', async function () {
     );
     await channel4Contract
       .connect(backendWallet)
-      .syncState([], [], CONTENT_TO_ADD);
+      .syncState([], [], CONTENT_TO_ADD, []);
 
     const allTags = await channel4Contract.getAllTags();
     const allContentInContract = await channel4Contract.getAllContent();
@@ -60,7 +62,7 @@ describe('Sync', async function () {
     );
     await channel4Contract
       .connect(backendWallet)
-      .syncState([], TAGS_TO_ADD, []);
+      .syncState([], TAGS_TO_ADD, [], []);
 
     const allContent = await channel4Contract.getAllContent();
     const allTags = await channel4Contract.getAllTags();
@@ -93,13 +95,44 @@ describe('Sync', async function () {
     );
     await channel4Contract
       .connect(backendWallet)
-      .syncState(USERS_TO_ADD, [], []);
+      .syncState(USERS_TO_ADD, [], [], []);
 
     const allUsersInContract = await channel4Contract.getAllUsers();
     const allUsersInBackend = [deployer.address, ...USERS_TO_ADD];
 
     for (let i = 0, ni = allUsersInContract.length; i < ni; i++) {
       expect(allUsersInContract[i].userAddress).to.equal(allUsersInBackend[i]);
+    }
+  });
+
+  it('Should succesfully load a bunch of likes to the contract state', async function () {
+    // load deployed contract fixture
+    const { channel4Contract, backendWallet } = await loadFixture(deployContractFixture);
+
+    // load accounts for test
+    const [deployer, alice, bob] = await ethers.getSigners();
+    const usersToAdd = [USER_PUBLIC_ADDRESS, alice.address, bob.address];
+    const allUsers = [deployer.address, ...usersToAdd];
+
+    // build likes
+    const pendingActions = [
+      { submittedBy: usersToAdd[0], url: CONTENT_TO_ADD[0].url },
+      { submittedBy: usersToAdd[1], url: CONTENT_TO_ADD[0].url },
+    ];
+
+    // sync state
+    await channel4Contract
+      .connect(backendWallet)
+      .syncState(usersToAdd, TAGS_TO_ADD, CONTENT_TO_ADD, pendingActions);
+
+    // check for existence of users with expected likes
+    const expectedLikes = [0, 1, 1, 0]
+    const contractUsers = await channel4Contract.getAllUsers();
+    for (let i = 0; i < contractUsers.length; i++) {
+      // check for expected address
+      expect(contractUsers[i].userAddress).to.equal(allUsers[i]);
+      // check for expected like #
+      expect(Number(contractUsers[i].numberOfLikedContent)).to.equal(expectedLikes[i]);
     }
   });
 });

--- a/test/sync.ts
+++ b/test/sync.ts
@@ -96,27 +96,10 @@ describe('Sync', async function () {
       .syncState(USERS_TO_ADD, [], []);
 
     const allUsersInContract = await channel4Contract.getAllUsers();
-    const allUsersInBackend = [
-      {
-        userAddress: deployer.address,
-        numberOfLikedContent: 0,
-        submittedContent: [0],
-      },
-    ].concat(USERS_TO_ADD);
+    const allUsersInBackend = [deployer.address, ...USERS_TO_ADD];
 
     for (let i = 0, ni = allUsersInContract.length; i < ni; i++) {
-      expect(allUsersInContract[i].userAddress).to.equal(
-        allUsersInBackend[i].userAddress,
-      );
-      expect(allUsersInContract[i].numberOfLikedContent).to.equal(
-        allUsersInBackend[i].numberOfLikedContent,
-      );
-
-      const submittedContentInContract = allUsersInContract[i].submittedContent;
-      const submittedContentInBackend = allUsersInBackend[i].submittedContent;
-      submittedContentInContract.forEach((contentIndex, j) => {
-        expect(Number(contentIndex)).to.equal(submittedContentInBackend[j]);
-      });
+      expect(allUsersInContract[i].userAddress).to.equal(allUsersInBackend[i]);
     }
   });
 });


### PR DESCRIPTION
 - changes like function to be a single function that toggles boolean on/off
 - adds `pendingActions` field to `syncState` to allow likes to be synced with the rest of backend state
 - adds unit test for syncing likes & updates impacted unit tests
 - merges in the deploy script pr 