### PR TITLE
Feat/rate limiting

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -20,7 +20,15 @@ export const SECOND_TITLE = 'Google';
 export const SECOND_URL = 'https://google.com/';
 export const SECOND_TAG = 'web-search';
 
-export const USERS_TO_ADD = [USER_PUBLIC_ADDRESS];
+export const USERS_TO_ADD = [
+  {
+    userAddress: USER_PUBLIC_ADDRESS,
+    numberOfLikes: 0,
+    submittedContent: [],
+    registeredAt: 0,
+    numberOfLikesInPeriod: 0,
+  },
+];
 export const TAGS_TO_ADD = [
   {
     name: 'music',

--- a/constants.ts
+++ b/constants.ts
@@ -13,8 +13,9 @@ export const VALUE_TO_RECHARGE = ethers.parseEther('0.01');
 export const TIME_THRESHOLD = BigInt(30);
 
 export const REGISTRATION_THRESHOLD = BigInt(60 * 60 * 24);
-export const LIKES_IN_PERIOD_THRESHOLD = BigInt(20);
+export const LIKES_IN_PERIOD_THRESHOLD = BigInt(3);
 export const REWARDS_AMOUNT = ethers.parseEther('0.0001');
+export const VALUE_TO_DONATE = ethers.parseEther('0.01');
 
 export const FIRST_TITLE = 'Privacy & Scaling Explorations';
 export const FIRST_URL = 'https://pse.dev/';

--- a/constants.ts
+++ b/constants.ts
@@ -12,6 +12,10 @@ export const VALUE_TO_RECHARGE = ethers.parseEther('0.01');
 
 export const TIME_THRESHOLD = BigInt(30);
 
+export const REGISTRATION_THRESHOLD = BigInt(60 * 60 * 24);
+export const LIKES_IN_PERIOD_THRESHOLD = BigInt(20);
+export const REWARDS_AMOUNT = ethers.parseEther('0.0001');
+
 export const FIRST_TITLE = 'Privacy & Scaling Explorations';
 export const FIRST_URL = 'https://pse.dev/';
 export const FIRST_TAG = 'zero-knowledge';

--- a/contracts/Channel4Contract.sol
+++ b/contracts/Channel4Contract.sol
@@ -4,22 +4,43 @@ pragma solidity ^0.8.9;
 import { Data } from "./Data.sol";
 import { Create } from "./Create.sol";
 import { Interact } from "./Interact.sol";
-
 import { Litigate } from "./Litigate.sol";
+import { Rewards } from "./Rewards.sol";
 
-contract Channel4Contract is Data, Create, Interact, Litigate {
+
+struct ConstructorObj {
+    string title;
+    string url;
+    string tag;
+    uint256 slashingFee;
+    uint256 backendRegistrationFee;
+    uint256 timeThreshold;
+    uint256 registrationThreshold;
+    uint256 likesInPeriodThreshold;
+    uint256 rewardsAmount;
+}
+
+contract Channel4Contract is Data, Create, Interact, Litigate, Rewards {
     constructor (
-        string memory title,
-        string memory url,
-        string memory tag,
-        uint256 slashingFee,
-        uint256 backendRegistrationFee,
-        uint256 timeThreshold
+        ConstructorObj memory constructorObj
     )
-    Data(title, url, tag)
+    Data(
+        constructorObj.title,
+        constructorObj.url,
+        constructorObj.tag
+    )
     Create()
     Interact()
-    Litigate(slashingFee, backendRegistrationFee, timeThreshold)
+    Litigate(
+        constructorObj.slashingFee,
+        constructorObj.backendRegistrationFee,
+        constructorObj.timeThreshold
+    )
+    Rewards(
+        constructorObj.registrationThreshold,
+        constructorObj.likesInPeriodThreshold,
+        constructorObj.rewardsAmount
+    )
     {}
 
     /// @notice Sync Content state with the backend. Only Content, Tag and User elements that have been updated

--- a/contracts/Channel4Contract.sol
+++ b/contracts/Channel4Contract.sol
@@ -24,18 +24,18 @@ contract Channel4Contract is Data, Create, Interact, Litigate {
 
     /// @notice Sync Content state with the backend. Only Content, Tag and User elements that have been updated
     /// @dev It can be called only by the backend to sync the state of the URLs
-    /// @param usersToAdd - addresses of new users to enroll in the contract
+    /// @param usersToSync - users to enroll/update in the contract
     /// @param tagsToAdd - tags to add to the contract
     /// @param contentsToAdd - url contents to add to the contract
     /// @param pendingActions - pending like/unlike actions to facilitate
     function syncState(
-        address[] calldata usersToAdd,
+        User[] calldata usersToSync,
         TagToSync[] calldata tagsToAdd,
         ContentToSync[] calldata contentsToAdd,
         Pending[] calldata pendingActions
     ) public onlyBackend {
-        for (uint256 i = 0; i < usersToAdd.length; i++)
-            _createUserIfNotExists(usersToAdd[i]);
+        for (uint256 i = 0; i < usersToSync.length; i++)
+            _createUserIfNotExists(usersToSync[i]);
         for (uint256 i = 0; i < tagsToAdd.length; i++) {
             _createTagIfNotExists(
                 tagsToAdd[i].name,

--- a/contracts/Create.sol
+++ b/contracts/Create.sol
@@ -115,7 +115,7 @@ abstract contract Create is Data, OnlyBackend {
         uint256 index = users.ids[userAddress];
         if (index == 0){
             // add new user to array
-            User memory newUser = User(userAddress, 0, new uint256[](0));
+            User memory newUser = User(userAddress, 0, new uint256[](0), block.timestamp);
             users.list.push(newUser);
             uint256 newIndex = users.list.length - 1;
             users.ids[userAddress] = newIndex;

--- a/contracts/Create.sol
+++ b/contracts/Create.sol
@@ -115,7 +115,7 @@ abstract contract Create is Data, OnlyBackend {
         uint256 index = users.ids[userAddress];
         if (index == 0){
             // add new user to array
-            User memory newUser = User(userAddress, 0, new uint256[](0), block.timestamp);
+            User memory newUser = User(userAddress, 0, new uint256[](0), block.timestamp, 0);
             users.list.push(newUser);
             uint256 newIndex = users.list.length - 1;
             users.ids[userAddress] = newIndex;

--- a/contracts/Data.sol
+++ b/contracts/Data.sol
@@ -19,7 +19,7 @@ abstract contract Data {
 
     struct User {
         address userAddress;
-        uint256 numberOfLikedContent;
+        uint256 numberOfLikes;
         uint256[] submittedContent;
         uint256 registeredAt;
         uint256 numberOfLikesInPeriod;
@@ -63,6 +63,14 @@ abstract contract Data {
     struct TagToSync {
         string name;
         address createdBy;
+    }
+
+    struct UserToSync {
+        address userAddress;
+        uint256 numberOfLikes;
+        string[] submittedContent;
+        uint256 registeredAt;
+        uint256 numberOfLikesInPeriod;
     }
 
     struct Pending {
@@ -190,7 +198,7 @@ abstract contract Data {
     function getUserLikedContent(address userAddress) public view returns (Content[] memory) {
         uint256 userIndex = users.ids[userAddress];
         uint256 resultIndex = 0;
-        Content [] memory result = new Content[](users.list[userIndex].numberOfLikedContent);
+        Content [] memory result = new Content[](users.list[userIndex].numberOfLikes);
         for (uint256 i = 0; i < contents.list.length; i++) {
             if (users.likedContent[userAddress][i].liked == true){
                 result[resultIndex] = contents.list[i];

--- a/contracts/Data.sol
+++ b/contracts/Data.sol
@@ -176,7 +176,7 @@ abstract contract Data {
     /// @param userAddress user address
     function getUser(address userAddress) public view returns (User memory) {
         uint256 index = users.ids[userAddress];
-        require(index < tags.list.length, "Invalid User index");
+        require(index < users.list.length, "Invalid User index");
         return users.list[index];
     }
 

--- a/contracts/Data.sol
+++ b/contracts/Data.sol
@@ -21,6 +21,7 @@ abstract contract Data {
         address userAddress;
         uint256 numberOfLikedContent;
         uint256[] submittedContent;
+        uint256 registeredAt;
     }
 
     struct Like {
@@ -107,7 +108,7 @@ abstract contract Data {
         contents.list.push(firstContent);
         contents.list[0].tagIds.push(0);
 
-        User memory newUser = User(msgSender, 0, new uint256[](0));
+        User memory newUser = User(msgSender, 0, new uint256[](0), block.timestamp);
         users.list.push(newUser);
         users.list[0].submittedContent.push(0);
         users.ids[msgSender] = 0;

--- a/contracts/Data.sol
+++ b/contracts/Data.sol
@@ -22,6 +22,7 @@ abstract contract Data {
         uint256 numberOfLikedContent;
         uint256[] submittedContent;
         uint256 registeredAt;
+        uint256 numberOfLikesInPeriod;
     }
 
     struct Like {
@@ -108,7 +109,7 @@ abstract contract Data {
         contents.list.push(firstContent);
         contents.list[0].tagIds.push(0);
 
-        User memory newUser = User(msgSender, 0, new uint256[](0), block.timestamp);
+        User memory newUser = User(msgSender, 0, new uint256[](0), block.timestamp, 0);
         users.list.push(newUser);
         users.list[0].submittedContent.push(0);
         users.ids[msgSender] = 0;

--- a/contracts/Interact.sol
+++ b/contracts/Interact.sol
@@ -29,9 +29,9 @@ abstract contract Interact is Data, OnlyBackend {
         // increment nonce related to user-content
         like.nonce = nonce;
         // increment or decrement user's liked content sum
-        user.numberOfLikedContent = liked
-            ? user.numberOfLikedContent + 1
-            : user.numberOfLikedContent - 1;
+        user.numberOfLikes = liked
+            ? user.numberOfLikes + 1
+            : user.numberOfLikes - 1;
         // increment or decrement content's like sum
         contents.list[contentId].likes = liked
             ? contents.list[contentId].likes + 1

--- a/contracts/Rewards.sol
+++ b/contracts/Rewards.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import { Data } from "./Data.sol";
+import { OnlyBackend } from "./OnlyBackend.sol";
+
+abstract contract Rewards is Data, OnlyBackend {
+
+    uint256 public rewardsVault = 0;
+
+    uint256 public lastMonth = 0;
+
+    uint256 private REGISTRATION_THRESHOLD = 1 days;
+
+    uint256 private LIKES_IN_PERIOD_THRESHOLD = 10;
+
+    uint256 private REWARDS_AMOUNT = 0.001 ether;
+
+
+    constructor(uint256 registrationThreshod, uint256 likesInPeriodThreshold, uint256 rewardsAmount) {
+        REGISTRATION_THRESHOLD = registrationThreshod;
+        LIKES_IN_PERIOD_THRESHOLD = likesInPeriodThreshold;
+        REWARDS_AMOUNT = rewardsAmount;
+        lastMonth = block.timestamp;
+    }
+
+    function withdrawRewards() public {
+        require(rewardsVault > 0, "Rewards vault is empty");
+        uint256 userIndex = users.ids[msg.sender];
+        User memory user = users.list[userIndex];
+        require(user.numberOfLikes > 0, "User has no given likes");
+        require(user.registeredAt > block.timestamp + REGISTRATION_THRESHOLD, "User is not registered");
+        require(user.numberOfLikesInPeriod > LIKES_IN_PERIOD_THRESHOLD, "User has not enough likes in period");
+        require(block.timestamp > lastMonth + 30 days, "It is not time to withdraw rewards yet");
+        // update the last month if 3 days have passed since last month
+        if (block.timestamp > lastMonth + 33 days) {
+            lastMonth = block.timestamp;
+        }
+        rewardsVault = rewardsVault - REWARDS_AMOUNT;
+        (bool success, ) = user.userAddress.call{ value: REWARDS_AMOUNT }("");
+        require(success, "Transfer to user failed.");
+    }
+
+    function receiveDonations() payable public {
+        rewardsVault = rewardsVault + msg.value;
+    }
+
+    function withdrawRemainingRewards() public onlyBackend {
+        require(rewardsVault > 0, "Rewards vault is empty");
+        rewardsVault = 0;
+        (bool success, ) = backendAddress.call{ value: rewardsVault }("");
+        require(success, "Transfer to backend failed.");
+    }
+}

--- a/contracts/Rewards.sol
+++ b/contracts/Rewards.sol
@@ -28,7 +28,6 @@ abstract contract Rewards is Data, OnlyBackend {
         require(rewardsVault > 0, "Rewards vault is empty");
         uint256 userIndex = users.ids[msg.sender];
         User memory user = users.list[userIndex];
-        require(user.numberOfLikes > 0, "User has no given likes");
         require(user.registeredAt > block.timestamp + REGISTRATION_THRESHOLD, "User is not registered");
         require(user.numberOfLikesInPeriod > LIKES_IN_PERIOD_THRESHOLD, "User has not enough likes in period");
         require(block.timestamp > lastMonth + 30 days, "It is not time to withdraw rewards yet");
@@ -47,8 +46,9 @@ abstract contract Rewards is Data, OnlyBackend {
 
     function withdrawRemainingRewards() public onlyBackend {
         require(rewardsVault > 0, "Rewards vault is empty");
+        uint256 valueToSend = rewardsVault;
         rewardsVault = 0;
-        (bool success, ) = backendAddress.call{ value: rewardsVault }("");
+        (bool success, ) = backendAddress.call{ value: valueToSend }("");
         require(success, "Transfer to backend failed.");
     }
 }

--- a/contracts/Rewards.sol
+++ b/contracts/Rewards.sol
@@ -28,7 +28,7 @@ abstract contract Rewards is Data, OnlyBackend {
         require(rewardsVault > 0, "Rewards vault is empty");
         uint256 userIndex = users.ids[msg.sender];
         User memory user = users.list[userIndex];
-        require(user.registeredAt > block.timestamp + REGISTRATION_THRESHOLD, "User is not registered");
+        require(user.registeredAt + REGISTRATION_THRESHOLD < block.timestamp, "User was recently registered");
         require(user.numberOfLikesInPeriod > LIKES_IN_PERIOD_THRESHOLD, "User has not enough likes in period");
         require(block.timestamp > lastMonth + 30 days, "It is not time to withdraw rewards yet");
         // update the last month if 3 days have passed since last month

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -23,8 +23,8 @@ const config: HardhatUserConfig = {
       url: `http://localhost:8545`,
       accounts: [
         '2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6',
-      ]
-    }
+      ],
+    },
   },
 };
 

--- a/test/create.ts
+++ b/test/create.ts
@@ -89,9 +89,13 @@ describe('Create', async function () {
   it("Should add new user if it doesn't exist", async function () {
     const { channel4Contract, otherAccount1, backendWallet } =
       await loadFixture(deployContractFixture);
-    await channel4Contract
-      .connect(backendWallet)
-      .createUserIfNotExists(otherAccount1.address);
+    await channel4Contract.connect(backendWallet).createUserIfNotExists({
+      userAddress: otherAccount1.address,
+      numberOfLikes: 0,
+      submittedContent: [],
+      registeredAt: 0,
+      numberOfLikesInPeriod: 0,
+    });
     const allUsers = await channel4Contract.getAllUsers();
     const timestamp = await time.latest();
     const user = allUsers[1];
@@ -108,9 +112,13 @@ describe('Create', async function () {
     const { channel4Contract, deployer, backendWallet } = await loadFixture(
       deployContractFixture,
     );
-    await channel4Contract
-      .connect(backendWallet)
-      .createUserIfNotExists(deployer.address);
+    await channel4Contract.connect(backendWallet).createUserIfNotExists({
+      userAddress: deployer.address,
+      numberOfLikes: 0,
+      submittedContent: [],
+      registeredAt: 0,
+      numberOfLikesInPeriod: 0,
+    });
     const allUsers = await channel4Contract.getAllUsers();
     expect(allUsers.length).to.equal(1);
   });

--- a/test/create.ts
+++ b/test/create.ts
@@ -69,7 +69,7 @@ describe('Create', async function () {
         otherAccount1.address,
         otherAccount2.address,
       ]).to.include(user.userAddress);
-      expect(Number(user.numberOfLikedContent)).to.equal(0);
+      expect(Number(user.numberOfLikes)).to.equal(0);
       expect(user.submittedContent.length).to.greaterThanOrEqual(0);
       expect(user.submittedContent.length).to.lessThanOrEqual(2);
       expect(user.submittedContent).to.contain.oneOf([BigInt(0), BigInt(1)]);
@@ -98,7 +98,7 @@ describe('Create', async function () {
 
     expect(allUsers.length).to.equal(2);
     expect(user.userAddress).to.equal(otherAccount1.address);
-    expect(Number(user.numberOfLikedContent)).to.equal(0);
+    expect(Number(user.numberOfLikes)).to.equal(0);
     expect(user.submittedContent.length).to.equal(0);
     expect(Number(user.registeredAt)).to.equal(timestamp);
     expect(Number(user.numberOfLikesInPeriod)).to.equal(0);

--- a/test/create.ts
+++ b/test/create.ts
@@ -93,7 +93,15 @@ describe('Create', async function () {
       .connect(backendWallet)
       .createUserIfNotExists(otherAccount1.address);
     const allUsers = await channel4Contract.getAllUsers();
+    const timestamp = await time.latest();
+    const user = allUsers[1];
+
     expect(allUsers.length).to.equal(2);
+    expect(user.userAddress).to.equal(otherAccount1.address);
+    expect(Number(user.numberOfLikedContent)).to.equal(0);
+    expect(user.submittedContent.length).to.equal(0);
+    expect(Number(user.registeredAt)).to.equal(timestamp);
+    expect(Number(user.numberOfLikesInPeriod)).to.equal(0);
   });
 
   it('Should not add user if it exists', async function () {
@@ -105,19 +113,5 @@ describe('Create', async function () {
       .createUserIfNotExists(deployer.address);
     const allUsers = await channel4Contract.getAllUsers();
     expect(allUsers.length).to.equal(1);
-  });
-
-  it('Should register the user creation timestamp', async function () {
-    const deployTime = await time.latest();
-    const { channel4Contract, otherAccount1, backendWallet } =
-      await loadFixture(deployContractFixture);
-    await channel4Contract
-      .connect(backendWallet)
-      .createUserIfNotExists(otherAccount1.address);
-    const allUsers = await channel4Contract.getAllUsers();
-    const timestamp = await time.latest();
-
-    expect(Number(allUsers[0].registeredAt)).to.be.approximately(deployTime, 3);
-    expect(Number(allUsers[1].registeredAt)).to.equal(timestamp);
   });
 });

--- a/test/create.ts
+++ b/test/create.ts
@@ -3,7 +3,7 @@ import {
   createContentIfNotExistsFixture,
   deployContractFixture,
 } from './fixtures';
-import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { loadFixture, time } from '@nomicfoundation/hardhat-network-helpers';
 import { FIRST_TAG, SECOND_TAG } from '../constants';
 
 describe('Create', async function () {
@@ -105,5 +105,19 @@ describe('Create', async function () {
       .createUserIfNotExists(deployer.address);
     const allUsers = await channel4Contract.getAllUsers();
     expect(allUsers.length).to.equal(1);
+  });
+
+  it('Should register the user creation timestamp', async function () {
+    const deployTime = await time.latest();
+    const { channel4Contract, otherAccount1, backendWallet } =
+      await loadFixture(deployContractFixture);
+    await channel4Contract
+      .connect(backendWallet)
+      .createUserIfNotExists(otherAccount1.address);
+    const allUsers = await channel4Contract.getAllUsers();
+    const timestamp = await time.latest();
+
+    expect(Number(allUsers[0].registeredAt)).to.be.approximately(deployTime, 3);
+    expect(Number(allUsers[1].registeredAt)).to.equal(timestamp);
   });
 });

--- a/test/deploy.ts
+++ b/test/deploy.ts
@@ -63,9 +63,13 @@ describe('Deploy', function () {
     ).to.be.revertedWith('Caller is not the backend');
 
     await expect(
-      channel4Contract
-        .connect(otherAccount1)
-        .createUserIfNotExists(otherAccount1.address),
+      channel4Contract.connect(otherAccount1).createUserIfNotExists({
+        userAddress: otherAccount1.address,
+        numberOfLikes: 0,
+        submittedContent: [],
+        registeredAt: 0,
+        numberOfLikesInPeriod: 0,
+      }),
     ).to.be.revertedWith('Caller is not the backend');
 
     await expect(

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -56,6 +56,13 @@ export async function createContentIfNotExistsFixture() {
     otherAccount2,
     backendWallet,
   } = await loadFixture(deployContractFixture);
+  await channel4Contract.connect(backendWallet).createUserIfNotExists({
+    userAddress: otherAccount1.address,
+    numberOfLikes: 0,
+    submittedContent: [],
+    registeredAt: 0,
+    numberOfLikesInPeriod: 0,
+  });
   const contentObj = {
     title: SECOND_TITLE,
     url: SECOND_URL,

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -5,6 +5,9 @@ import {
   FIRST_TAG,
   FIRST_TITLE,
   FIRST_URL,
+  LIKES_IN_PERIOD_THRESHOLD,
+  REGISTRATION_THRESHOLD,
+  REWARDS_AMOUNT,
   SECOND_TAG,
   SECOND_TITLE,
   SECOND_URL,
@@ -24,14 +27,17 @@ export async function deployContractFixture() {
   const [deployer, otherAccount1, otherAccount2] = await ethers.getSigners();
 
   const Channel4Contract = await ethers.getContractFactory('Channel4Contract');
-  const channel4Contract = await Channel4Contract.deploy(
-    FIRST_TITLE,
-    FIRST_URL,
-    FIRST_TAG,
-    SLASHING_FEE,
-    BACKEND_REGISTRATION_FEE,
-    TIME_THRESHOLD,
-  );
+  const channel4Contract = await Channel4Contract.deploy({
+    title: FIRST_TITLE,
+    url: FIRST_URL,
+    tag: FIRST_TAG,
+    slashingFee: SLASHING_FEE,
+    backendRegistrationFee: BACKEND_REGISTRATION_FEE,
+    timeThreshold: TIME_THRESHOLD,
+    registrationThreshold: REGISTRATION_THRESHOLD,
+    likesInPeriodThreshold: LIKES_IN_PERIOD_THRESHOLD,
+    rewardsAmount: REWARDS_AMOUNT,
+  });
 
   const backendWallet = new ethers.Wallet(BACKEND_PRIVATE_KEY, ethers.provider);
   await setBalance(backendWallet.address, BACKEND_REGISTRATION_FEE * 3n);

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -104,10 +104,10 @@ export async function likeContentFixture() {
     contentObj,
     backendWallet,
   } = await loadFixture(createContentIfNotExistsFixture);
-  const nonce = 1;
+  const nonceAccount1 = 1;
   await channel4Contract
     .connect(backendWallet)
-    .toggleLike(contentObj.url, true, nonce, otherAccount1.address);
+    .toggleLike(contentObj.url, true, nonceAccount1, otherAccount1.address);
   return {
     channel4Contract,
     deployer,
@@ -115,7 +115,7 @@ export async function likeContentFixture() {
     otherAccount2,
     contentObj,
     backendWallet,
-    nonce,
+    nonceAccount1,
   };
 }
 

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -13,6 +13,7 @@ import {
   SECOND_URL,
   SLASHING_FEE,
   TIME_THRESHOLD,
+  VALUE_TO_DONATE,
 } from '../constants';
 import {
   loadFixture,
@@ -200,5 +201,25 @@ export async function prepareEIP712LitigateLikeFixture() {
     domain,
     types,
     backendWallet,
+  };
+}
+
+export async function prepareWithdrawRewardsFixture() {
+  const { channel4Contract, backendWallet, otherAccount1 } = await loadFixture(
+    deployContractFixture,
+  );
+  await channel4Contract.receiveDonations({ value: VALUE_TO_DONATE });
+  // you need to create a user first
+  await channel4Contract.connect(backendWallet).createUserIfNotExists({
+    userAddress: otherAccount1.address,
+    numberOfLikes: 0,
+    submittedContent: [],
+    registeredAt: 0,
+    numberOfLikesInPeriod: 0,
+  });
+  return {
+    channel4Contract,
+    backendWallet,
+    otherAccount1,
   };
 }

--- a/test/like.ts
+++ b/test/like.ts
@@ -23,12 +23,17 @@ describe('Like', async function () {
       contentObj,
       otherAccount1,
       backendWallet,
-      nonce,
+      nonceAccount1,
     } = await loadFixture(likeContentFixture);
 
     await channel4Contract
       .connect(backendWallet)
-      .toggleLike(contentObj.url, false, nonce + 1, otherAccount1.address);
+      .toggleLike(
+        contentObj.url,
+        false,
+        nonceAccount1 + 1,
+        otherAccount1.address,
+      );
     const content = await channel4Contract.getContent(contentObj.url);
     expect(Number(content.likes)).to.equal(0);
 

--- a/test/rewards.ts
+++ b/test/rewards.ts
@@ -1,6 +1,9 @@
 import { loadFixture, time } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
-import { deployContractFixture } from './fixtures';
+import {
+  deployContractFixture,
+  prepareWithdrawRewardsFixture,
+} from './fixtures';
 import { REGISTRATION_THRESHOLD, VALUE_TO_DONATE } from '../constants';
 import { ethers } from 'hardhat';
 
@@ -45,15 +48,15 @@ describe('Rewards', async function () {
 
   it('Should succesfully withdraw rewards from user', async () => {
     const { channel4Contract, backendWallet, otherAccount1 } =
-      await loadFixture(deployContractFixture);
+      await loadFixture(prepareWithdrawRewardsFixture);
+    // you can modify the user object with the sync function
     await channel4Contract.connect(backendWallet).syncState(
       [
         {
           userAddress: otherAccount1.address,
           numberOfLikes: 7,
           submittedContent: [],
-          registeredAt:
-            BigInt(await time.latest()) + REGISTRATION_THRESHOLD + BigInt(1),
+          registeredAt: BigInt(await time.latest()),
           numberOfLikesInPeriod: 5,
         },
       ],
@@ -61,15 +64,103 @@ describe('Rewards', async function () {
       [],
       [],
     );
-    await channel4Contract.receiveDonations({ value: VALUE_TO_DONATE });
+    await time.increase(BigInt(60 * 60 * 24 * 30));
     await channel4Contract.connect(otherAccount1).withdrawRewards();
   });
 
-  it('Should prevent withdraw if likes are not enough', async () => {});
+  it('Should prevent withdraw if likes are not enough', async () => {
+    const { channel4Contract, backendWallet, otherAccount1 } =
+      await loadFixture(prepareWithdrawRewardsFixture);
+    // you can modify the user object with the sync function
+    await channel4Contract.connect(backendWallet).syncState(
+      [
+        {
+          userAddress: otherAccount1.address,
+          numberOfLikes: 7,
+          submittedContent: [],
+          registeredAt: BigInt(await time.latest()),
+          numberOfLikesInPeriod: 3,
+        },
+      ],
+      [],
+      [],
+      [],
+    );
+    await time.increase(BigInt(60 * 60 * 24 * 30));
+    await expect(
+      channel4Contract.connect(otherAccount1).withdrawRewards(),
+    ).to.be.revertedWith('User has not enough likes in period');
+  });
 
-  it('Should prevent withdraw if user was registered recently', async () => {});
+  it('Should prevent withdraw if user was registered recently', async () => {
+    const { channel4Contract, backendWallet, otherAccount1 } =
+      await loadFixture(prepareWithdrawRewardsFixture);
+    // you can modify the user object with the sync function
+    await channel4Contract.connect(backendWallet).syncState(
+      [
+        {
+          userAddress: otherAccount1.address,
+          numberOfLikes: 7,
+          submittedContent: [],
+          registeredAt: BigInt(await time.latest()),
+          numberOfLikesInPeriod: 5,
+        },
+      ],
+      [],
+      [],
+      [],
+    );
+    await time.increase(REGISTRATION_THRESHOLD - BigInt(10));
+    await expect(
+      channel4Contract.connect(otherAccount1).withdrawRewards(),
+    ).to.be.revertedWith('User was recently registered');
+  });
 
-  it('Should prevent withdraw if user called it before end of month', async () => {});
+  it('Should prevent withdraw if user called it before end of month', async () => {
+    const { channel4Contract, backendWallet, otherAccount1 } =
+      await loadFixture(prepareWithdrawRewardsFixture);
+    // you can modify the user object with the sync function
+    await channel4Contract.connect(backendWallet).syncState(
+      [
+        {
+          userAddress: otherAccount1.address,
+          numberOfLikes: 7,
+          submittedContent: [],
+          registeredAt: BigInt(await time.latest()),
+          numberOfLikesInPeriod: 5,
+        },
+      ],
+      [],
+      [],
+      [],
+    );
+    await time.increase(BigInt(60 * 60 * 24 * 29));
+    await expect(
+      channel4Contract.connect(otherAccount1).withdrawRewards(),
+    ).to.be.revertedWith('It is not time to withdraw rewards yet');
+  });
 
-  it('Should succesfully update the last month value', async () => {});
+  it('Should succesfully update the last month value', async () => {
+    const { channel4Contract, backendWallet, otherAccount1 } =
+      await loadFixture(prepareWithdrawRewardsFixture);
+    // you can modify the user object with the sync function
+    await channel4Contract.connect(backendWallet).syncState(
+      [
+        {
+          userAddress: otherAccount1.address,
+          numberOfLikes: 7,
+          submittedContent: [],
+          registeredAt: BigInt(await time.latest()),
+          numberOfLikesInPeriod: 5,
+        },
+      ],
+      [],
+      [],
+      [],
+    );
+    await time.increase(BigInt(60 * 60 * 24 * 33));
+    await channel4Contract.connect(otherAccount1).withdrawRewards();
+    const lastMonthAfter = await channel4Contract.lastMonth();
+    expect(lastMonthAfter).to.equal(BigInt(await time.latest()));
+  });
 });

--- a/test/rewards.ts
+++ b/test/rewards.ts
@@ -1,7 +1,7 @@
-import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { loadFixture, time } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
-import { deployContractFixture, likeContentFixture } from './fixtures';
-import { VALUE_TO_DONATE } from '../constants';
+import { deployContractFixture } from './fixtures';
+import { REGISTRATION_THRESHOLD, VALUE_TO_DONATE } from '../constants';
 import { ethers } from 'hardhat';
 
 describe('Rewards', async function () {
@@ -44,12 +44,25 @@ describe('Rewards', async function () {
   });
 
   it('Should succesfully withdraw rewards from user', async () => {
-    const { channel4Contract, backendWallet, otherAccount2, contentObj } =
-      await loadFixture(likeContentFixture);
-    const nonceAccount2 = 1;
-    await channel4Contract
-      .connect(backendWallet)
-      .toggleLike(contentObj.url, true, nonceAccount2, otherAccount2.address);
+    const { channel4Contract, backendWallet, otherAccount1 } =
+      await loadFixture(deployContractFixture);
+    await channel4Contract.connect(backendWallet).syncState(
+      [
+        {
+          userAddress: otherAccount1.address,
+          numberOfLikes: 7,
+          submittedContent: [],
+          registeredAt:
+            BigInt(await time.latest()) + REGISTRATION_THRESHOLD + BigInt(1),
+          numberOfLikesInPeriod: 5,
+        },
+      ],
+      [],
+      [],
+      [],
+    );
+    await channel4Contract.receiveDonations({ value: VALUE_TO_DONATE });
+    await channel4Contract.connect(otherAccount1).withdrawRewards();
   });
 
   it('Should prevent withdraw if likes are not enough', async () => {});

--- a/test/rewards.ts
+++ b/test/rewards.ts
@@ -1,0 +1,62 @@
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import { deployContractFixture, likeContentFixture } from './fixtures';
+import { VALUE_TO_DONATE } from '../constants';
+import { ethers } from 'hardhat';
+
+describe('Rewards', async function () {
+  it('Should succesfully receive donations', async () => {
+    const { channel4Contract } = await loadFixture(deployContractFixture);
+    const contractBalanceBefore = await ethers.provider.getBalance(
+      await channel4Contract.getAddress(),
+    );
+    const rewardsVaultBefore = await channel4Contract.rewardsVault();
+    await channel4Contract.receiveDonations({ value: VALUE_TO_DONATE });
+    const rewardsVaultAfter = await channel4Contract.rewardsVault();
+    const contractBalanceAfter = await ethers.provider.getBalance(
+      await channel4Contract.getAddress(),
+    );
+
+    expect(rewardsVaultAfter).to.equal(rewardsVaultBefore + VALUE_TO_DONATE);
+    expect(contractBalanceAfter).to.equal(
+      contractBalanceBefore + VALUE_TO_DONATE,
+    );
+  });
+
+  it('Should successfully withdraw rewards from backend', async () => {
+    const { channel4Contract, backendWallet } = await loadFixture(
+      deployContractFixture,
+    );
+    await channel4Contract.receiveDonations({ value: VALUE_TO_DONATE });
+    const contractBalanceBefore = await ethers.provider.getBalance(
+      await channel4Contract.getAddress(),
+    );
+    await channel4Contract.connect(backendWallet).withdrawRemainingRewards();
+    const rewardsVaultAfter = await channel4Contract.rewardsVault();
+    const contractBalanceAfter = await ethers.provider.getBalance(
+      await channel4Contract.getAddress(),
+    );
+
+    expect(rewardsVaultAfter).to.equal(0);
+    expect(contractBalanceAfter).to.equal(
+      contractBalanceBefore - VALUE_TO_DONATE,
+    );
+  });
+
+  it('Should succesfully withdraw rewards from user', async () => {
+    const { channel4Contract, backendWallet, otherAccount2, contentObj } =
+      await loadFixture(likeContentFixture);
+    const nonceAccount2 = 1;
+    await channel4Contract
+      .connect(backendWallet)
+      .toggleLike(contentObj.url, true, nonceAccount2, otherAccount2.address);
+  });
+
+  it('Should prevent withdraw if likes are not enough', async () => {});
+
+  it('Should prevent withdraw if user was registered recently', async () => {});
+
+  it('Should prevent withdraw if user called it before end of month', async () => {});
+
+  it('Should succesfully update the last month value', async () => {});
+});

--- a/test/sync.ts
+++ b/test/sync.ts
@@ -144,9 +144,7 @@ describe('Sync', async function () {
       // check for expected address
       expect(contractUsers[i].userAddress).to.equal(allUsers[i]);
       // check for expected like #
-      expect(Number(contractUsers[i].numberOfLikedContent)).to.equal(
-        expectedLikes[i],
-      );
+      expect(Number(contractUsers[i].numberOfLikes)).to.equal(expectedLikes[i]);
     }
   });
 });

--- a/test/sync.ts
+++ b/test/sync.ts
@@ -120,6 +120,7 @@ describe('Sync', async function () {
       for (let j = 0, nj = contentInContract.length; j < nj; j++) {
         expect(Number(contentInContract[j])).to.equal(contentInBackend[j]);
       }
+      // it is a bit hard to check the registeredAt timestamp so we leave that one in /test/create.ts
       expect(Number(allUsersInContract[i].numberOfLikesInPeriod)).to.equal(
         allUsersInBackend[i].numberOfLikesInPeriod,
       );

--- a/test/sync.ts
+++ b/test/sync.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import { deployContractFixture } from './fixtures';
-import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { loadFixture, time } from '@nomicfoundation/hardhat-network-helpers';
 import {
   CONTENT_TO_ADD,
   FIRST_TAG,
@@ -9,7 +9,6 @@ import {
   FIRST_URL,
   TAGS_TO_ADD,
   USERS_TO_ADD,
-  USER_PUBLIC_ADDRESS,
 } from '../constants';
 
 describe('Sync', async function () {
@@ -98,10 +97,32 @@ describe('Sync', async function () {
       .syncState(USERS_TO_ADD, [], [], []);
 
     const allUsersInContract = await channel4Contract.getAllUsers();
-    const allUsersInBackend = [deployer.address, ...USERS_TO_ADD];
+    const allUsersInBackend = [
+      {
+        userAddress: deployer.address,
+        numberOfLikes: 0,
+        submittedContent: [0],
+        registeredAt: await time.latest(),
+        numberOfLikesInPeriod: 0,
+      },
+      ...USERS_TO_ADD,
+    ];
 
     for (let i = 0, ni = allUsersInContract.length; i < ni; i++) {
-      expect(allUsersInContract[i].userAddress).to.equal(allUsersInBackend[i]);
+      expect(allUsersInContract[i].userAddress).to.equal(
+        allUsersInBackend[i].userAddress,
+      );
+      expect(Number(allUsersInContract[i].numberOfLikes)).to.equal(
+        allUsersInBackend[i].numberOfLikes,
+      );
+      const contentInContract = allUsersInContract[i].submittedContent;
+      const contentInBackend = allUsersInBackend[i].submittedContent;
+      for (let j = 0, nj = contentInContract.length; j < nj; j++) {
+        expect(Number(contentInContract[j])).to.equal(contentInBackend[j]);
+      }
+      expect(Number(allUsersInContract[i].numberOfLikesInPeriod)).to.equal(
+        allUsersInBackend[i].numberOfLikesInPeriod,
+      );
     }
   });
 
@@ -113,19 +134,44 @@ describe('Sync', async function () {
 
     // load accounts for test
     const [deployer, alice, bob] = await ethers.getSigners();
-    const usersToAdd = [USER_PUBLIC_ADDRESS, alice.address, bob.address];
-    const allUsers = [deployer.address, ...usersToAdd];
+    const usersToAdd = [
+      USERS_TO_ADD[0],
+      {
+        userAddress: alice.address,
+        numberOfLikes: 0,
+        submittedContent: [],
+        registeredAt: 0,
+        numberOfLikesInPeriod: 0,
+      },
+      {
+        userAddress: bob.address,
+        numberOfLikes: 0,
+        submittedContent: [],
+        registeredAt: 0,
+        numberOfLikesInPeriod: 0,
+      },
+    ];
+    const allUsers = [
+      {
+        userAddress: deployer.address,
+        numberOfLikes: 0,
+        submittedContent: [0],
+        registeredAt: await time.latest(),
+        numberOfLikesInPeriod: 0,
+      },
+      ...usersToAdd,
+    ];
 
     // build likes
     const pendingActions = [
       {
-        submittedBy: usersToAdd[0],
+        submittedBy: usersToAdd[0].userAddress,
         url: CONTENT_TO_ADD[0].url,
         liked: true,
         nonce: 1,
       },
       {
-        submittedBy: usersToAdd[1],
+        submittedBy: usersToAdd[1].userAddress,
         url: CONTENT_TO_ADD[0].url,
         liked: true,
         nonce: 1,
@@ -142,7 +188,7 @@ describe('Sync', async function () {
     const contractUsers = await channel4Contract.getAllUsers();
     for (let i = 0; i < contractUsers.length; i++) {
       // check for expected address
-      expect(contractUsers[i].userAddress).to.equal(allUsers[i]);
+      expect(contractUsers[i].userAddress).to.equal(allUsers[i].userAddress);
       // check for expected like #
       expect(Number(contractUsers[i].numberOfLikes)).to.equal(expectedLikes[i]);
     }


### PR DESCRIPTION
This PR implements the following regarding #9: 

1. A rewards vault to register donations and allow users to withdraw rewards depending on their activity
1. A mechanism to verify that a user was registered before a threshold
1. A mechanism to verify that the user has enough likes in the period
1. A mechanism to verify the function is being called at the end of each month

It also implements these changes not related to rate limiting:
1. Update whole user object when using sync
1. Rename user number of likes attribute 

Closes #9 #8 